### PR TITLE
changing besnappy not to use cloud front

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -209,4 +209,4 @@
 
       ga('create', 'UA-52190726-1', 'auto');
 
-    %script{:type=>"text/javascript", :src=>"//d2s6cp23z9c3gz.cloudfront.net/js/embed.widget.min.js", :data => {:domain=>"meinbge.besnappy.com", :lang=>"de", :title=>"Hilfe und Kontakt", :position=>"bottom left"}}
+    %script{:type=>"text/javascript", :src=>"https://app.besnappy.com/js/embed.widget.min.js", :data => {:domain=>"meinbge.besnappy.com", :lang=>"de", :title=>"Hilfe und Kontakt", :position=>"bottom left"} }


### PR DESCRIPTION
the besnappy widget.js seems load itself twice if you use the cloudfront url (or mix http and https), but loading it from the app.besnappy.com url saves a second load...

The besnappy documentation is a bit fuzzy (you need to log in to see the snippet), so if there's a good reason for using cloudfront, let me know