### PR TITLE
Clarify user information on raffles

### DIFF
--- a/app/assets/templates/profile.html
+++ b/app/assets/templates/profile.html
@@ -47,7 +47,7 @@
   <ul ng-if="own_profile">
     <li ng-if="!current.participates() && current.settings['raffleOpen']">Bitte erst <a href="/boarding?trigger=wants_to_participate">hier</a> an der Verlosung teilnehmen.</li>
 
-    <li ng-if="!current.participates() && !current.settings['raffleOpen']">Noch ist die Teilnahme für die nächste Verlosung nicht geöffnet. Wenn du den Newsletter abboniert hast, informieren wir dich rechtzeitig. Crowdhörnchen nehmen automatisch an jeder Verlosung teil.</li>
+    <li ng-if="!current.participates() && !current.settings['raffleOpen']">Sobald die nächste Verlosung feststeht, kannst du daran teilnehmen. Deine Losnummer findest du dann hier. Wenn du den Newsletter abboniert hast, informieren wir dich rechtzeitig. Crowdhörnchen nehmen automatisch an jeder Verlosung teil.</li>
 
     <li ng-if="current.participates()">Du nimmst an der nächsten Verlosung teil.</li>
 


### PR DESCRIPTION
Avoid support requests by giving more detailed information on when and where to find code and information about unscheduled upcoming raffle.